### PR TITLE
xdg_cache_home not root

### DIFF
--- a/src/pysme/large_file_storage.py
+++ b/src/pysme/large_file_storage.py
@@ -24,6 +24,7 @@ from astropy.utils.data import (
 from tqdm.auto import tqdm
 from tqdm.utils import CallbackIOWrapper
 
+from .config import Config
 from .util import show_progress_bars
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
removing root sacrificing threadsafe. I don't think pysme is threadsafe anyway? 
I also added the import back that I removed by accident.

If someone is using both pysme and astropy, this might mess with their astropy file storage. Should note this in the documentation somewhere. The only way to properly fix this would be to not use astropy for the file download. This is a bigger change, but I would recommend it instead of my bandaid fix. 